### PR TITLE
Add `MonadFail` constraints where `fail` is used

### DIFF
--- a/src/Parquet/Utils.hs
+++ b/src/Parquet/Utils.hs
@@ -11,7 +11,11 @@ import qualified Data.Text as T
 
 infixl 4 <??>
 
-failOnExcept :: Monad m => ExceptT T.Text m a -> m a
+failOnExcept ::
+  ( Monad m,
+    MonadFail m
+  ) =>
+  ExceptT T.Text m a -> m a
 failOnExcept =
   runExceptT >=> \case
     Left err -> fail (T.unpack err)


### PR DESCRIPTION
Like I said I'll just try to keep building on top of previous branches so this should go in after #4 is merged.